### PR TITLE
setup: remove tests from output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
         "Programming Language :: Python",
     ],
     python_requires=">=3.3",
-    packages=find_packages(),
+    packages=find_packages(exclude=("test",)),
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,6 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-if sys.version_info[:3] < (3, 3):
-    raise SystemExit("You need Python 3.3+")
-
-
 setup(
     name="jesd204b",
     version="0.11",
@@ -31,6 +27,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
+    python_requires=">=3.3",
     packages=find_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
Makes two changes:
* use standard setuptools logic for python_requires. This has been included in setuptools since v24.2.0, July 2016.
* Exclude the test directory from being copied to the output directory. This is especially critical for Nix, where (accidentally) repeated test directories can cause collisions that prevent environments from being built.
